### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -119,7 +119,7 @@ data locally using a `LOCAL`, client Region, without the need to setup or run an
 
 NOTE: Spring recommends the production, enterprise edition that is https://pivotal.io/pivotal-gemfire[Pivotal GemFire],
 where you can create distributed caches and Regions across multiple nodes in cluster.  Alternatively, you can also use
-the open source version, http://geode.apache.org/[Apache Geode], and get support from the Apache Geode community.
+the open source version, https://geode.apache.org/[Apache Geode], and get support from the Apache Geode community.
 
 Now, remember how you tagged `Person` to be stored in a Region called "People" using the SDG mapping annotation,
 `@Region("People")`? You define that Region here using the `ClientRegionFactoryBean<String, Person>` bean definition.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://geode.apache.org/ with 1 occurrences migrated to:  
  https://geode.apache.org/ ([https](https://geode.apache.org/) result 200).